### PR TITLE
Using centos:6 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:6.4
+FROM centos:6
 
 MAINTAINER Mikael Gueck, gumi@iki.fi
 


### PR DESCRIPTION
6.4 does not seem to exist anymore in DockerHub